### PR TITLE
Add DejaVu fonts to fix tofu rendering in system tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     sudo build-essential curl wget vim \
     bzr git mercurial subversion cvs \
+    fonts-dejavu-core fonts-dejavu-extra \
     ghostscript \
     gsfonts \
     imagemagick libmagick++-dev \

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -9,6 +9,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     sudo build-essential curl wget vim \
     bzr git mercurial subversion cvs \
+    fonts-dejavu-core fonts-dejavu-extra \
     ghostscript \
     gsfonts \
     imagemagick libmagick++-dev \


### PR DESCRIPTION
`⇈` displays as tofu.
<img width="190" height="101" alt="Screenshot 2025-10-26 at 13 52 32" src="https://github.com/user-attachments/assets/c9875bd5-d5b0-40bd-83ae-4584ac8cf08d" />
